### PR TITLE
Unmesh added code to calculate displacement factor for every test case in predict option

### DIFF
--- a/include/trident/kb/consts.h
+++ b/include/trident/kb/consts.h
@@ -40,6 +40,8 @@
 #endif
 
 //This is a list of all permutation IDs. It is replicated in tridentcompr/Compressor.h
+// Use IDX_SPO : to find all possible Os where S and P are fixed
+// Use IDX_POS : to find all possible Ss where O and P are fixed
 #define IDX_SPO 0
 #define IDX_OPS 1
 #define IDX_POS 2

--- a/include/trident/ml/tester.h
+++ b/include/trident/ml/tester.h
@@ -3,6 +3,7 @@
 
 #include <trident/ml/embeddings.h>
 #include <trident/kb/kb.h>
+#include <trident/kb/querier.h>
 #include <trident/utils/json.h>
 
 #include <kognac/logs.h>
@@ -12,14 +13,31 @@
 #include <iostream>
 #include <string>
 #include <sstream>
+#include <unordered_map>
 
 using namespace std;
+
+
+// Code inspired from
+// https://stackoverflow.com/questions/32685540/unordered-map-with-pair-as-key-not-compiling
+struct pair_hash {
+
+    template <class T1, class T2>
+    std::size_t operator() (const std::pair<T1,T2> &p) const {
+        auto h1 = std::hash<T1>{}(p.first);
+        auto h2 = std::hash<T2>{}(p.second);
+
+        h1 ^= h2 + 0x9e3779b9 + (h2 << 6) + (h2 >> 2);
+        return h1;
+    }
+};
 
 template<typename K>
 class Tester {
     private:
         std::shared_ptr<Embeddings<K>> E;
         std::shared_ptr<Embeddings<K>> R;
+        Querier* q;
 
         static uint64_t getPos(const uint64_t ne, const std::vector<double> &scores,
                 std::vector<size_t> &indices,
@@ -42,6 +60,8 @@ class Tester {
             uint64_t hit10S = 0;
             uint64_t hit3S = 0;
             uint64_t hit3O = 0;
+            uint64_t displacementO = 0;
+            uint64_t displacementS = 0;
         };
 
         struct ResSingleQuery {
@@ -76,6 +96,11 @@ class Tester {
             uint64_t hit10S = 0;
             uint64_t hit3S = 0;
             uint64_t hit3O = 0;
+            vector<uint64_t> vecPositionsO;
+            vector<uint64_t> vecPositionsS;
+            uint64_t sumAvgDisplacementO = 0;
+            uint64_t sumAvgDisplacementS = 0;
+            unordered_map<pair<uint64_t, uint64_t>, uint64_t, pair_hash> spoToDisMap;
 
             int64_t counter = 0;
             int stepperc = 10;
@@ -85,6 +110,7 @@ class Tester {
                 uint64_t s = testset[start];
                 uint64_t p = testset[start+1];
                 uint64_t o = testset[start+2];
+
                 start += 3;
 
                 //Test objects
@@ -97,6 +123,7 @@ class Tester {
                 hit10O += posO <= 10;
                 hit3O += posO <= 3;
 
+
                 //Test subjects
                 predictS(test, pR->get(p), dimr, pE->get(o), dime);
                 for(uint64_t idx = 0; idx < ne; ++idx) {
@@ -106,6 +133,93 @@ class Tester {
                 positionsS += posS;
                 hit10S += posS <= 10;
                 hit3S += posS <= 3;
+
+                //===============================================================================================
+                // Code to compute displacement begins
+                // +
+
+                DictMgmt* dict =  q->getDictMgmt();
+                string sub;
+                string pred;
+                string obj;
+                dict->getText(s, sub);
+                dict->getText(p, pred);
+                dict->getText(o, obj);
+
+                // Fire query to get all possible objects
+                auto itr = q->getPermuted(IDX_SPO, s, p, -1, true);
+                uint64_t countResultsO = 0;
+                uint64_t displacementO = 0;
+                // Clear the vector
+                vector<uint64_t>().swap(vecPositionsO);
+
+                if (spoToDisMap.find(make_pair(s,p)) == spoToDisMap.end()){
+                    while (itr->hasNext()) {
+                        itr->next();
+                        //string s1;
+                        //string s2;
+                        //string s3;
+                        //dict->getText(itr->getKey(), s1);
+                        //dict->getText(itr->getValue1(), s2);
+                        //dict->getText(itr->getValue2(), s3);
+                        uint64_t object = itr->getValue2();
+                        const uint64_t posO = getPos(ne, scores, indices, indices2, object) + 1;
+                        vecPositionsO.push_back(posO);
+                        countResultsO += 1;
+                    }
+                    uint64_t nAnswersO = vecPositionsO.size();
+                    for (auto position : vecPositionsO) {
+                        uint64_t abs_diff = (position > nAnswersO) ? (position - nAnswersO): (nAnswersO - position);
+                        assert(abs_diff<=INT64_MAX);
+                        int64_t dis =  (position > nAnswersO) ? (int64_t)abs_diff : -(int64_t)abs_diff;
+                        if (dis > 0){
+                            displacementO += dis;
+                        }
+                    }
+                    sumAvgDisplacementO += displacementO / countResultsO;
+                    spoToDisMap[make_pair(s,p)] = displacementO / countResultsO;
+                } else {
+                    sumAvgDisplacementO += spoToDisMap[make_pair(s,p)];
+                }
+
+                // Order POS in IDX_POS also determines order of parameters we pass to getPermuted()
+                itr = q->getPermuted(IDX_POS, p, o, -1, true);
+                uint64_t countResultsS = 0;
+                uint64_t displacementS = 0;
+                vector<uint64_t>().swap(vecPositionsS);
+                if (spoToDisMap.find(make_pair(p,o)) == spoToDisMap.end()) {
+                    while(itr->hasNext()) {
+                        itr->next();
+                        uint64_t subject = itr->getValue2();
+                        string temp;
+                        dict->getText(subject, temp);
+                        //LOG(DEBUGL) << temp << " => " << pred << " , " <<  obj;
+                        const uint64_t posS = getPos(ne, scores, indices, indices2, subject) + 1;
+                        vecPositionsS.push_back(posS);
+                        countResultsS += 1;
+                    }
+                    uint64_t nAnswersS = vecPositionsS.size();
+                    for (auto position : vecPositionsS) {
+                        uint64_t abs_diff = (position > nAnswersS) ? (position - nAnswersS): (nAnswersS - position);
+                        assert(abs_diff<=INT64_MAX);
+                        int64_t dis =  (position > nAnswersS) ? (int64_t)abs_diff : -(int64_t)abs_diff;
+                        if (dis > 0) {
+                            displacementS += dis;
+                        }
+                    }
+                    sumAvgDisplacementS += displacementS / countResultsS;
+                    spoToDisMap[make_pair(p,o)] = displacementS / countResultsS;
+                } else {
+                    //LOG(DEBUGL) << "(" << p << " , " << o << ") = " << spoToDisMap[make_pair(p,o)];
+                    sumAvgDisplacementS += spoToDisMap[make_pair(p,o)];
+                }
+                //LOG(DEBUGL) << pred << ", " << obj << "has answers :";
+                LOG(DEBUGL) << "Test set # " << start << " : #tuples (o) = " << countResultsO  << " dis = " << displacementO\
+                << " ,#tuples (s) = " << countResultsS << " dis = " << displacementS;
+
+                // -
+                // Code to compute displacement ends
+                //===============================================================================================
 
                 //Track progress
                 counter++;
@@ -131,6 +245,8 @@ class Tester {
             out->hit10S = hit10S;
             out->hit3O = hit3O;
             out->hit3S = hit3S;
+            out->displacementO = sumAvgDisplacementO;
+            out->displacementS = sumAvgDisplacementS;
         }
 
     public:
@@ -138,6 +254,14 @@ class Tester {
                 std::shared_ptr<Embeddings<K>> R) {
             this->E = E;
             this->R = R;
+        }
+
+        Tester(std::shared_ptr<Embeddings<K>> E,
+               std::shared_ptr<Embeddings<K>> R,
+               Querier *q) {
+            this->E = E;
+            this->R = R;
+            this->q = q;
         }
 
         struct OutputTest {
@@ -167,6 +291,7 @@ class Tester {
             uint64_t triplesPerThread = ntriples / nthreads;
             uint64_t nelsPerThread = triplesPerThread * 3;
 
+            LOG(DEBUGL) << "test set size = " << testset.size();
             size_t start = 0;
             for(uint16_t i = 0; i < nthreads; ++i) {
                 size_t end = 0;
@@ -193,6 +318,8 @@ class Tester {
             uint64_t hit10S = 0;
             uint64_t hit3S = 0;
             uint64_t hit3O = 0;
+            uint64_t sumDisplacementsO = 0;
+            uint64_t sumDisplacementsS = 0;
             //Collect the numbers
             for(uint16_t i = 0; i < nthreads; ++i) {
                 positionsO += outputs[i].positionsO;
@@ -201,6 +328,8 @@ class Tester {
                 hit10S += outputs[i].hit10S;
                 hit3O += outputs[i].hit3O;
                 hit3S += outputs[i].hit3S;
+                sumDisplacementsO += outputs[i].displacementO;
+                sumDisplacementsS += outputs[i].displacementS;
             }
 
             //return the output statistics
@@ -215,9 +344,12 @@ class Tester {
             double avghit3 = (avghit3s + avghit3o) / 2;
             std::chrono::duration<double> elapsed_seconds = std::chrono::system_clock::now() - starttime;
 
+
             LOG(INFOL) << "Time: " << elapsed_seconds.count() << " sec. Mean subj pos: " << avgsubj << " Mean obj pos: " << avgobj << " Mean pos: " << totalavg;
             LOG(INFOL) << "Hit@10(s): " << avghit10s << "% Hit@10(o): " << avghit10o << "% Hit@10: " << avghit10 << "%";
             LOG(INFOL) << "Hit@3(s): " << avghit3s << "% Hit@3(o): " << avghit3o << "% Hit@3: " << avghit3 << "%";
+            LOG(INFOL) << "**** sum Displacement(o) : " << sumDisplacementsO;
+            LOG(INFOL) << "**** sum Displacement(s) : " << sumDisplacementsS;
 
             //Write JSON output
             JSON jsonresults;

--- a/include/trident/ml/transetester.h
+++ b/include/trident/ml/transetester.h
@@ -7,6 +7,10 @@ template<typename K>
 class TranseTester : public Tester<K> {
     public:
         TranseTester(std::shared_ptr<Embeddings<K>> E,
+               std::shared_ptr<Embeddings<K>> R, Querier* q) : Tester<K>(E, R, q) {
+        }
+
+        TranseTester(std::shared_ptr<Embeddings<K>> E,
                std::shared_ptr<Embeddings<K>> R) : Tester<K>(E, R) {
         }
 

--- a/src/trident/ml/main_ml.cpp
+++ b/src/trident/ml/main_ml.cpp
@@ -123,11 +123,11 @@ void launchML(KB &kb, string op, string algo, string paramsLearn,
                 return;
             }
         }
-        if (mapparams.count("modele")) {
-            p.path_modele = mapparams["modele"];
+        if (mapparams.count("path_modele")) {
+            p.path_modele = mapparams["path_modele"];
         }
-        if (mapparams.count("modelr")) {
-            p.path_modelr = mapparams["modelr"];
+        if (mapparams.count("path_modelr")) {
+            p.path_modelr = mapparams["path_modelr"];
         }
         if (mapparams.count("nametestset")) {
             p.nametestset = mapparams["nametestset"];

--- a/src/trident/ml/tester.cpp
+++ b/src/trident/ml/tester.cpp
@@ -35,7 +35,7 @@ void Predictor::launchPrediction(KB &kb, string algo, PredictParams &p) {
     BatchCreator::loadTriples(pathtest, testset);
 
     if (algo == "transe") {
-        TranseTester<double> tester(E,R);
+        TranseTester<double> tester(E,R, kb.query());
         auto result = tester.test(p.nametestset, testset, p.nthreads, 0);
     } else {
         LOG(ERRORL) << "Not yet supported";


### PR DESCRIPTION
when we use trident with `./trident predict  -i location/of/trident/db --algo transe `,
For every test case (i.e. for every triple <s,p,o>, we find out

1. all possible objects for given **s** and **p**
2. all possible subjects for given **p** and **o**

1.1 for all objects, say we find N objects o1, o2, o3,... oN
1.2 For each object, we find its position based on **transe** embeddings (p1, p2, ...pN)
1.3 Then we compute avg(p1-N, p2-N,..., PN - N)

2.1 for all subjects, say we find N subjects s1, s2,... oN
2.2 For each subject, we find its position based on **transe** embeddings (p1, p2, ...pN)
2.3 Then we compute avg(p1-N, p2-N,..., PN - N)

