### PR TITLE
Add missing <cstdint> include

### DIFF
--- a/include/trident/sparql/aggrhandler.h
+++ b/include/trident/sparql/aggrhandler.h
@@ -1,6 +1,7 @@
 #ifndef _AGGR_HDL_H
 #define _AGGR_HDL_H
 
+#include <cstdint>
 #include <vector>
 #include <map>
 


### PR DESCRIPTION
`include/trident/sparql/aggrhandler.h` is missing a `<cstdint>` include, which breaks the build.