### PR TITLE
Fixed compilation on modern GCC

### DIFF
--- a/include/trident/model/table.h
+++ b/include/trident/model/table.h
@@ -31,6 +31,7 @@
 #include <vector>
 #include <iostream>
 #include <assert.h>
+#include <memory>
 
 class TupleTable {
 private:

--- a/src/trident/model/table.cpp
+++ b/src/trident/model/table.cpp
@@ -26,6 +26,7 @@
 #include <string>
 #include <cstring>
 #include <cmath>
+#include <memory>
 
 bool TupleTableItr::same(const int64_t l1, const int64_t l2) const {
     return table->getPosAtRow(l1, 0) == table->getPosAtRow(l2, 0) &&


### PR DESCRIPTION
Added #include <memory> where needed to make trident compile on modern versions of GCC.